### PR TITLE
Establishing canonical links for search engines

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,6 +25,7 @@
   {% if data_file and page.author and data_file.cognomen[page.author] %}
     {% assign post_author_name = data_file.cognomen[page.author] %}
     {% assign post_author_url = data_file.authorlinks[post_author_name] %}
+    {% assign post_author_baseurl = data_file.base_sites[post_author_name] %}
     {% assign post_author_css = data_file.authorstyles[post_author_name] %}
     {% if post_author_css %}
       <link rel="stylesheet" href="{{ site.baseurl }}/assets/{{ post_author_css }}">
@@ -44,7 +45,7 @@
   
   {% comment %} If the post has a different author URL, that URL should be canonical {% endcomment %}
   {% if post_author_url %}
-    <link rel="canonical" href="{{ post_author_url }}{{ page.url }}">
+    <link rel="canonical" href="{{ post_author_baseurl }}{{ page.url }}">
   {% else %}
     <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,6 +42,13 @@
     {% assign reg_author = site.compass.author %}
   {% endif %}
   
+  {% comment %} If the post has a different author URL, that URL should be canonical {% endcomment %}
+  {% if post_author_url %}
+    <link rel="canonical" href="{{ post_author_url }}{{ page.url }}">
+  {% else %}
+    <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  {% endif %}
+  
   {% if page.title %}
     <title>{{ page.title | strip_html }} &#8226; {{ reg_author }}</title>
   {% else %}
@@ -69,7 +76,6 @@
 	  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/latest.js?config=TeX-AMS-MML_HTMLorMML">
   </script>
 
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
   <meta name="author" content="{{ reg_author }}">
 
   {% if page.url == "/" %}


### PR DESCRIPTION
@andburch before you pull this, make sure to pull the changes to `_posts` first.

This should completely solve the search engine problem: it essentially is a way of giving "credit" to the "original" pages, so the original author's site should come up for each post, and google won't think we're duplicating stuff.